### PR TITLE
Update SpoolProcessor.cpp

### DIFF
--- a/Source/Processor/SpoolProcessor.cpp
+++ b/Source/Processor/SpoolProcessor.cpp
@@ -117,8 +117,8 @@ void SpoolProcessor::prepareToPlay (double sampleRate, int samplesPerBlock) {
     processSpec.maximumBlockSize = samplesPerBlock;
     processSpec.numChannels = getTotalNumOutputChannels();
     
-    sequencer->prepareToPlay(samplesPerBlock, sampleRate);
-    tracks->prepareToPlay(samplesPerBlock, sampleRate);
+    sequencer->prepareToPlay(sampleRate, samplesPerBlock);
+    tracks->prepareToPlay(sampleRate, samplesPerBlock);
     // Use this method as the place to do any pre-playback
     // initialisation that you need..
 }


### PR DESCRIPTION
in prepare() method the 'sampleRate' and 'samplesPerBlock' were being passed to the samples/tracks in reverse order of the arguments.  I just switched their places